### PR TITLE
fix: put bitarray swap in the system temp path vs a relative path

### DIFF
--- a/ci/mac.yml
+++ b/ci/mac.yml
@@ -50,7 +50,7 @@ steps:
 
   - script: |
       cd $(Build.SourcesDirectory)/src
-      make -j$(nproc)
+      make
     displayName: 'Build hobbits'
 
   - script: |

--- a/src/hobbits-core/bitarray.cpp
+++ b/src/hobbits-core/bitarray.cpp
@@ -3,6 +3,7 @@
 #include <QRegularExpression>
 #include <QSharedPointer>
 #include <QString>
+#include <QDir>
 
 static char BIT_MASKS[8] = {
     -128, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01
@@ -17,7 +18,7 @@ static char INVERSE_BIT_MASKS[8] = {
 #define MAX_ACTIVE_CACHE_CHUNKS 5
 
 BitArray::BitArray() :
-    m_dataFile("bitarray"),
+    m_dataFile(QDir::temp().absoluteFilePath("bitarray")),
     m_size(0),
     m_dataCaches(nullptr)
 {


### PR DESCRIPTION
Using QTemporaryFile without specifying an absolute system temp path in the name template was making the files relative to the cwd, which was '/' for mac app bundles executed from the GUI/Finder (which resulted in the crashing described in #37)