### PR TITLE
Allows project to build without HOBBITS_PYPATH

### DIFF
--- a/src/hobbits-runner/main.cpp
+++ b/src/hobbits-runner/main.cpp
@@ -11,11 +11,12 @@
 #include "hobbitspluginmanager.h"
 #include "settingsmanager.h"
 #include <QJsonArray>
-#include "pythonpluginconfig.h"
+
 #include <QTimer>
 
 #ifdef HAS_EMBEDDED_PYTHON
 #include "hobbitspython.h"
+#include "pythonpluginconfig.h"
 #endif
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Small change that removes a build error caused by missing headers when building without HOBBITS_PYPATH set.