### PR TITLE
fix value instances not appearing

### DIFF
--- a/src/hobbits-plugins/analyzers/KaitaiStruct/scripts/runner.py
+++ b/src/hobbits-plugins/analyzers/KaitaiStruct/scripts/runner.py
@@ -83,12 +83,14 @@ def parse_struct(struct, sections, prefix="", parent_offset = 0, base_io=None, b
     #print(vars(struct))
     #print(struct._debug)
     
-    for name, info in struct._debug.items():
-        try:
-            value = getattr(struct, name)
-        except:
-            print(f"Skipping {name}, not an attribute in struct")
+    for name, value in struct.__dict__.items():
+        if name in ("_io", "_parent", "_root", "_debug") or name.startswith("_raw_"):
             continue
+
+        if name in struct._debug:
+            info = struct._debug[name]
+        else:
+            info = {"start": 0, "end": 0}
 
         label = prefix + "." + name if prefix else name
         parent_offset = info["start"] + base_offset


### PR DESCRIPTION
Changed the parse_struct function in the KaitaiStruct runner python script to iterate over every attribute of the struct to fix it not seeing instances set by value.