### PR TITLE
fix: Auto-expand tree in Bit Containers view (#150)

### DIFF
--- a/src/hobbits-gui/mainwindow.cpp
+++ b/src/hobbits-gui/mainwindow.cpp
@@ -536,6 +536,7 @@ void MainWindow::activateBitContainer(QSharedPointer<BitContainer> selected, QSh
     }
     else {
         ui->tb_removeBitContainer->setEnabled(true);
+        ui->tv_bitContainers->expand(m_bitContainerManager->getCurrSelectionModel()->selectedIndexes().first());
     }
     setCurrentBitContainer();
 }


### PR DESCRIPTION
Simple fix which automatically expands the selected index in the tree view from the current selection model whenever a bit container is activated.