### PR TITLE
feat: add setting for numerical base of addresses

### DIFF
--- a/src/hobbits-plugins/displays/Hex/hex.cpp
+++ b/src/hobbits-plugins/displays/Hex/hex.cpp
@@ -12,6 +12,7 @@ Hex::Hex() :
     QList<ParameterDelegate::ParameterInfo> infos = {
         {"font_size", ParameterDelegate::ParameterType::Integer},
         {"column_grouping", ParameterDelegate::ParameterType::Integer},
+        {"address_display_base", ParameterDelegate::ParameterType::Integer},
         {"show_headers", ParameterDelegate::ParameterType::Boolean}
     };
 
@@ -130,6 +131,7 @@ QSharedPointer<DisplayResult> Hex::renderOverlay(QSize viewportSize, const Param
 
     QSize fontSize = DisplayHelper::textSize(DisplayHelper::monoFont(m_lastParams.value("font_size").toInt()), "0");
     int columnGrouping = m_lastParams.value("column_grouping").toInt();
+    int addressDisplayBase = m_lastParams.value("address_display_base").toInt();
 
     auto overlay = DisplayHelper::drawHeadersFull(
                 viewportSize,
@@ -137,7 +139,8 @@ QSharedPointer<DisplayResult> Hex::renderOverlay(QSize viewportSize, const Param
                 m_handle,
                 QSizeF(double(fontSize.width()) / 4.0, DisplayHelper::textRowHeight(fontSize.height())),
                 columnGrouping,
-                columnGrouping > 1 ? 1 : 0);
+                columnGrouping > 1 ? 1 : 0,
+                addressDisplayBase);
 
     return DisplayResult::result(overlay, parameters);
 }

--- a/src/hobbits-plugins/displays/Hex/hexform.cpp
+++ b/src/hobbits-plugins/displays/Hex/hexform.cpp
@@ -8,12 +8,14 @@ HexForm::HexForm(QSharedPointer<ParameterDelegate> delegate):
     ui->setupUi(this);
 
     connect(ui->sb_columnGrouping, SIGNAL(valueChanged(int)), this, SIGNAL(changed()));
+    connect(ui->sb_addressDisplayBase, SIGNAL(valueChanged(int)), this, SIGNAL(changed()));
     connect(ui->hs_fontSize, SIGNAL(valueChanged(int)), this, SIGNAL(changed()));
     connect(ui->cb_showHeaders, SIGNAL(stateChanged(int)), this, SIGNAL(changed()));
 
     m_paramHelper->addSliderIntParameter("font_size", ui->hs_fontSize);
     m_paramHelper->addCheckBoxBoolParameter("show_headers", ui->cb_showHeaders);
     m_paramHelper->addSpinBoxIntParameter("column_grouping", ui->sb_columnGrouping);
+    m_paramHelper->addSpinBoxIntParameter("address_display_base", ui->sb_addressDisplayBase);
 }
 
 HexForm::~HexForm()

--- a/src/hobbits-widgets/displayhelper.cpp
+++ b/src/hobbits-widgets/displayhelper.cpp
@@ -300,7 +300,8 @@ QImage DisplayHelper::drawHeadersFull(QSize viewportSize,
                                       QSharedPointer<DisplayHandle> handle,
                                       QSizeF bitSize,
                                       int columnGrouping,
-                                      int groupMargin)
+                                      int groupMargin,
+                                      int addressDisplayBase)
 {
     if (offset.x() == 0 && offset.y() == 0) {
         return QImage();
@@ -315,7 +316,11 @@ QImage DisplayHelper::drawHeadersFull(QSize viewportSize,
     DisplayHelper::drawFramesHeader(&painter,
                                     QSize(offset.x(), viewportSize.height() - offset.y()),
                                     handle,
-                                    bitSize.height());
+                                    bitSize.height(),
+                                    Qt::Vertical,
+                                    1,
+                                    0,
+                                    addressDisplayBase);
 
     DisplayHelper::drawFramesHeader(&painter,
                                     QSize(viewportSize.width() - offset.x(), offset.y()),
@@ -323,7 +328,8 @@ QImage DisplayHelper::drawHeadersFull(QSize viewportSize,
                                     bitSize.width(),
                                     Qt::Horizontal,
                                     columnGrouping,
-                                    groupMargin);
+                                    groupMargin,
+                                    addressDisplayBase);
 
     return headers;
 }
@@ -334,7 +340,8 @@ void DisplayHelper::drawFramesHeader(QPainter *painter,
                                      double frameHeight,
                                      int orientation,
                                      int grouping,
-                                     int groupMargin)
+                                     int groupMargin,
+                                     int addressDisplayBase)
 {
     painter->save();
 
@@ -395,7 +402,7 @@ void DisplayHelper::drawFramesHeader(QPainter *painter,
                 textSize,
                 fontSize.height(),
                 textAlign,
-                QString("%1").arg(i + offset));
+                QString("%1").arg(i + offset, 0, addressDisplayBase));
     }
 
     if (highlightOffset >= 0) {
@@ -429,7 +436,7 @@ void DisplayHelper::drawFramesHeader(QPainter *painter,
         painter->drawText(
                 textRect,
                 textAlign,
-                QString("%1").arg(highlightOffset));
+                QString("%1").arg(highlightOffset, 0, addressDisplayBase));
     }
 
     painter->restore();
@@ -662,4 +669,3 @@ void DisplayHelper::sendHoverUpdate(QSharedPointer<DisplayHandle> handle, QPoint
 
     handle->setBitHover(true, diff.x(), diff.y());
 }
-

--- a/src/hobbits-widgets/displayhelper.h
+++ b/src/hobbits-widgets/displayhelper.h
@@ -58,7 +58,8 @@ namespace DisplayHelper
                                                       QSharedPointer<DisplayHandle> displayHandle,
                                                       QSizeF bitSize,
                                                       int columnGrouping = 1,
-                                                      int groupMargin = 0);
+                                                      int groupMargin = 0,
+                                                      int addressDisplayBase = 10);
 
     void HOBBITSWIDGETSSHARED_EXPORT drawFramesHeader(QPainter *painter,
                                                       QSize viewportSize,
@@ -66,7 +67,8 @@ namespace DisplayHelper
                                                       double frameHeight,
                                                       int orientation = Qt::Vertical,
                                                       int grouping = 1,
-                                                      int groupMargin = 0);
+                                                      int groupMargin = 0,
+                                                      int addressDisplayBase = 10);
 
 
     void HOBBITSWIDGETSSHARED_EXPORT drawHoverBox(QPainter *painter,


### PR DESCRIPTION
Resolves #160 

So, this does it for the hex display... but two things I'd like feedback on. First, I should probably use a dropdown instead of a spinbox because nobody wants base 15. Also, now that I'm using this more (great software, btw!), I noticed that most of the other display plugins have the same setting. So would you be alright with me putting this in the settings dialog, rather than in each area separately?