### PR TITLE
Use Qt versionless target to allow for Qt5 and Qt6 compatibility.

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -56,6 +56,6 @@ jobs:
 
       - uses: actions/download-artifact@v3
           
-      - name: Display structure of downloaded files
+      - name: Check Files
         run: ls -R
 

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -9,7 +9,11 @@ on:
       - develop
 jobs:
   Build-Hobbits:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ubuntu-20.04, ubuntu-22.04]
+
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -41,5 +45,17 @@ jobs:
         run: ninja package -C build
       - uses: actions/upload-artifact@v3
         with:
-          name: DEB Packages
+          name: DEB Packages ${{ matrix.os }}
           path: build/hobbits-*deb*
+      
+  Check-Artifacts:
+    needs: Build-Hobbits
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
+          
+      - name: Display structure of downloaded files
+        run: ls -R
+

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,4 +1,4 @@
-name: Build Hobbits
+name: Build and Test develop
 run-name: Build ${{ github.ref }} ${{ github.sha }}
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - develop
 jobs:
   Build-Hobbits:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy Hobbits
+name: Build, Test and Release master
 run-name: Deploy ${{ github.ref }} ${{ github.sha }}
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - master
 jobs:
   Build-Hobbits:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -6,7 +6,11 @@ on:
       - master
 jobs:
   Build-Hobbits:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ubuntu-20.04, ubuntu-22.04]
+
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -44,11 +48,26 @@ jobs:
         run: ninja package -C build
       - uses: actions/upload-artifact@v3
         with:
-          name: DEB Packages
+          name: DEB Packages ${{ matrix.os }}
           path: build/hobbits-*deb*
+
+  Release-Hobbits:
+    needs: Build-Hobbits
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
+          
+      - name: Check Files
+        run: ls -R
 
       - name: Semantic Release
         run: |
+          npm ci
           cp ci/full.releaserc.json .releaserc.json
           npx semantic-release
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ elseif( MANUAL_PYTHON_PATH )
 	set ( Python3_ROOT_DIR "${MANUAL_PYTHON_PATH}" )
 endif()
 
-find_package (Python3 3.9 COMPONENTS Interpreter Development REQUIRED)
+find_package (Python3 3.8 COMPONENTS Interpreter Development REQUIRED)
 message("Python3 Libs: ${Python3_LIBRARIES}")
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,9 +127,10 @@ else()
 	find_package(PkgConfig)
 
 	# Qt
-	find_package(Qt5Core CONFIG REQUIRED)
-	find_package(Qt5Widgets CONFIG REQUIRED)
-	find_package(Qt5Network CONFIG REQUIRED)
+	find_package(Qt6 COMPONENTS Core Widgets Network)
+	if (NOT Qt6_FOUND)
+		find_package(Qt5 5.15 REQUIRED COMPONENTS Core Widgets Network)
+	endif()
 
 	# libpcap
 	if (NOT WIN32)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Discord Chat](https://discordapp.com/api/guilds/672761400220844042/widget.png?style=shield)](https://discord.gg/wRQJpZZ)
 ![build, test, release master](https://github.com/Mahlet-Inc/hobbits/actions/workflows/prod-build.yml/badge.svg)
-![build, test develop](https://github.com/Mahlet-Inc/hobbits/actions/workflows/dev-build.yml/badge.svg?event=push)|
+![build, test develop](https://github.com/Mahlet-Inc/hobbits/actions/workflows/dev-build.yml/badge.svg?event=push)
 
 
 ## About

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Discord Chat](https://discordapp.com/api/guilds/672761400220844042/widget.png?style=shield)](https://discord.gg/wRQJpZZ)
-
-| master | develop |
-| ------ | ------- |
-|![main](https://github.com/Mahlet-Inc/hobbits/actions/workflows/prod-build.yml/badge.svg)|![main](https://github.com/Mahlet-Inc/hobbits/actions/workflows/dev-build.yml/badge.svg?event=push)|
+![build, test, release master](https://github.com/Mahlet-Inc/hobbits/actions/workflows/prod-build.yml/badge.svg)
+![build, test develop](https://github.com/Mahlet-Inc/hobbits/actions/workflows/dev-build.yml/badge.svg?event=push)|
 
 
 ## About

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Discord Chat](https://discordapp.com/api/guilds/672761400220844042/widget.png?style=shield)](https://discord.gg/wRQJpZZ)
-![build, test, release master](https://github.com/Mahlet-Inc/hobbits/actions/workflows/prod-build.yml/badge.svg)
-![build, test develop](https://github.com/Mahlet-Inc/hobbits/actions/workflows/dev-build.yml/badge.svg?event=push)
+[![build, test, release master](https://github.com/Mahlet-Inc/hobbits/actions/workflows/prod-build.yml/badge.svg)](https://github.com/Mahlet-Inc/hobbits/actions/workflows/prod-build.yml)
+[![build, test develop](https://github.com/Mahlet-Inc/hobbits/actions/workflows/dev-build.yml/badge.svg?event=push)](https://github.com/Mahlet-Inc/hobbits/actions/workflows/dev-build.yml)
 
 
 ## About

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-[![Discord Chat](https://discordapp.com/api/guilds/672761400220844042/widget.png?style=shield)](https://discord.gg/wRQJpZZ)  
+[![Discord Chat](https://discordapp.com/api/guilds/672761400220844042/widget.png?style=shield)](https://discord.gg/wRQJpZZ)
+
+| master | develop |
+| ------ | ------- |
+|![main](https://github.com/Mahlet-Inc/hobbits/actions/workflows/prod-build.yml/badge.svg)|![main](https://github.com/Mahlet-Inc/hobbits/actions/workflows/dev-build.yml/badge.svg?event=push)|
+
 
 ## About
 Hobbits was developed at Mahlet in 2019 as an integrated data analysis tool. It was open-sourced

--- a/ci/full.releaserc.json
+++ b/ci/full.releaserc.json
@@ -25,7 +25,12 @@
             {
                 "assets": [
                     {
-                        "path": "build/hobbits*deb*"
+                        "path": "DEB Packages ubuntu-20.04/*.deb",
+                        "name": "DEB Package for Ubuntu 20.04"
+                    },
+                    {
+                        "path": "DEB Packages ubuntu-22.04/*.deb",
+                        "name": "DEB Package for Ubuntu 22.04"
                     }
                 ]
             }

--- a/src/hobbits-core/CMakeLists.txt
+++ b/src/hobbits-core/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(hobbits-core INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 if (BUILDING_WITH_CONAN)
 	set(ALL_LINK_LIBS CONAN_PKG::qt)
 else()
-	set(ALL_LINK_LIBS Qt5::Core Qt5::Widgets)
+	set(ALL_LINK_LIBS Qt::Core Qt::Widgets)
 endif()
 
 target_link_libraries(hobbits-core ${ALL_LINK_LIBS})

--- a/src/hobbits-gui/CMakeLists.txt
+++ b/src/hobbits-gui/CMakeLists.txt
@@ -19,7 +19,7 @@ file(GLOB RCFILES "${CMAKE_CURRENT_SOURCE_DIR}/*.qrc" "${CMAKE_CURRENT_SOURCE_DI
 if (BUILDING_WITH_CONAN)
 	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core CONAN_PKG::qt)
 else()
-	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core Qt5::Widgets)
+	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core Qt::Widgets)
 endif()
 
 add_executable(hobbits MACOSX_BUNDLE "${SRCFILES}" "${HDRFILES}" "${RCFILES}")

--- a/src/hobbits-plugins/CMakeLists.txt
+++ b/src/hobbits-plugins/CMakeLists.txt
@@ -18,7 +18,7 @@ macro(pluginInDir pluginType modName modDir)
 		if (BUILDING_WITH_CONAN)
 			set(ALL_LINK_LIBS hobbits-core hobbits-widgets CONAN_PKG::qt)
 		else()
-			set(ALL_LINK_LIBS hobbits-core hobbits-widgets Qt5::Core Qt5::Widgets)
+			set(ALL_LINK_LIBS hobbits-core hobbits-widgets Qt::Core Qt::Widgets)
 		endif()
 
         target_link_libraries("${pluginName}" PRIVATE ${ALL_LINK_LIBS})

--- a/src/hobbits-plugins/importerexporters/HttpData/CMakeLists.txt
+++ b/src/hobbits-plugins/importerexporters/HttpData/CMakeLists.txt
@@ -1,6 +1,6 @@
 pluginInDir("${pluginType}" "HttpData" "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (NOT BUILDING_WITH_CONAN)
-	target_link_libraries("hobbits-plugin-importerexporters-HttpData" PRIVATE Qt5::Network)
+	target_link_libraries("hobbits-plugin-importerexporters-HttpData" PRIVATE Qt::Network)
 endif()
     

--- a/src/hobbits-plugins/importerexporters/PacketCapture/CMakeLists.txt
+++ b/src/hobbits-plugins/importerexporters/PacketCapture/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT WIN32)
 	if (BUILDING_WITH_CONAN)
 		target_link_libraries("hobbits-plugin-importerexporters-PacketCapture" PRIVATE CONAN_PKG::libpcap)
 	else()
-		target_link_libraries("hobbits-plugin-importerexporters-PacketCapture" PRIVATE ${PCAP_LIBRARY} Qt5::Network)
+		target_link_libraries("hobbits-plugin-importerexporters-PacketCapture" PRIVATE ${PCAP_LIBRARY} Qt::Network)
 	endif()
     
 endif()

--- a/src/hobbits-plugins/importerexporters/TcpData/CMakeLists.txt
+++ b/src/hobbits-plugins/importerexporters/TcpData/CMakeLists.txt
@@ -1,5 +1,5 @@
 pluginInDir("${pluginType}" "TcpData" "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (NOT BUILDING_WITH_CONAN)
-	target_link_libraries("hobbits-plugin-importerexporters-TcpData" PRIVATE Qt5::Network)
+	target_link_libraries("hobbits-plugin-importerexporters-TcpData" PRIVATE Qt::Network)
 endif()

--- a/src/hobbits-plugins/importerexporters/UdpData/CMakeLists.txt
+++ b/src/hobbits-plugins/importerexporters/UdpData/CMakeLists.txt
@@ -1,5 +1,5 @@
 pluginInDir("${pluginType}" "UdpData" "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (NOT BUILDING_WITH_CONAN)
-	target_link_libraries("hobbits-plugin-importerexporters-UdpData" PRIVATE Qt5::Network)
+	target_link_libraries("hobbits-plugin-importerexporters-UdpData" PRIVATE Qt::Network)
 endif()

--- a/src/hobbits-runner/CMakeLists.txt
+++ b/src/hobbits-runner/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable("hobbits-runner" "${SRCFILES}"  "${HDRFILES}" "${RCFILES}")
 if (BUILDING_WITH_CONAN)
 	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core CONAN_PKG::qt)
 else()
-	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core Qt5::Widgets)
+	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core Qt::Widgets)
 endif()
 
 target_link_libraries("hobbits-runner" ${ALL_LINK_LIBS})


### PR DESCRIPTION
Qt 5.15 introduced versionless package detection to allow for Qt 5 & Qt6 compatibility.

https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html