### PR TITLE
Use Qt versionless target to allow for Qt5 and Qt6 compatibility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,9 +127,10 @@ else()
 	find_package(PkgConfig)
 
 	# Qt
-	find_package(Qt5Core CONFIG REQUIRED)
-	find_package(Qt5Widgets CONFIG REQUIRED)
-	find_package(Qt5Network CONFIG REQUIRED)
+	find_package(Qt6 COMPONENTS Core Widgets Network)
+	if (NOT Qt6_FOUND)
+		find_package(Qt5 5.15 REQUIRED COMPONENTS Core Widgets Network)
+	endif()
 
 	# libpcap
 	if (NOT WIN32)

--- a/src/hobbits-core/CMakeLists.txt
+++ b/src/hobbits-core/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(hobbits-core INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 if (BUILDING_WITH_CONAN)
 	set(ALL_LINK_LIBS CONAN_PKG::qt)
 else()
-	set(ALL_LINK_LIBS Qt5::Core Qt5::Widgets)
+	set(ALL_LINK_LIBS Qt::Core Qt::Widgets)
 endif()
 
 target_link_libraries(hobbits-core ${ALL_LINK_LIBS})

--- a/src/hobbits-gui/CMakeLists.txt
+++ b/src/hobbits-gui/CMakeLists.txt
@@ -19,7 +19,7 @@ file(GLOB RCFILES "${CMAKE_CURRENT_SOURCE_DIR}/*.qrc" "${CMAKE_CURRENT_SOURCE_DI
 if (BUILDING_WITH_CONAN)
 	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core CONAN_PKG::qt)
 else()
-	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core Qt5::Widgets)
+	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core Qt::Widgets)
 endif()
 
 add_executable(hobbits MACOSX_BUNDLE "${SRCFILES}" "${HDRFILES}" "${RCFILES}")

--- a/src/hobbits-plugins/CMakeLists.txt
+++ b/src/hobbits-plugins/CMakeLists.txt
@@ -18,7 +18,7 @@ macro(pluginInDir pluginType modName modDir)
 		if (BUILDING_WITH_CONAN)
 			set(ALL_LINK_LIBS hobbits-core hobbits-widgets CONAN_PKG::qt)
 		else()
-			set(ALL_LINK_LIBS hobbits-core hobbits-widgets Qt5::Core Qt5::Widgets)
+			set(ALL_LINK_LIBS hobbits-core hobbits-widgets Qt::Core Qt::Widgets)
 		endif()
 
         target_link_libraries("${pluginName}" PRIVATE ${ALL_LINK_LIBS})

--- a/src/hobbits-plugins/importerexporters/HttpData/CMakeLists.txt
+++ b/src/hobbits-plugins/importerexporters/HttpData/CMakeLists.txt
@@ -1,6 +1,6 @@
 pluginInDir("${pluginType}" "HttpData" "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (NOT BUILDING_WITH_CONAN)
-	target_link_libraries("hobbits-plugin-importerexporters-HttpData" PRIVATE Qt5::Network)
+	target_link_libraries("hobbits-plugin-importerexporters-HttpData" PRIVATE Qt::Network)
 endif()
     

--- a/src/hobbits-plugins/importerexporters/PacketCapture/CMakeLists.txt
+++ b/src/hobbits-plugins/importerexporters/PacketCapture/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT WIN32)
 	if (BUILDING_WITH_CONAN)
 		target_link_libraries("hobbits-plugin-importerexporters-PacketCapture" PRIVATE CONAN_PKG::libpcap)
 	else()
-		target_link_libraries("hobbits-plugin-importerexporters-PacketCapture" PRIVATE ${PCAP_LIBRARY} Qt5::Network)
+		target_link_libraries("hobbits-plugin-importerexporters-PacketCapture" PRIVATE ${PCAP_LIBRARY} Qt::Network)
 	endif()
     
 endif()

--- a/src/hobbits-plugins/importerexporters/TcpData/CMakeLists.txt
+++ b/src/hobbits-plugins/importerexporters/TcpData/CMakeLists.txt
@@ -1,5 +1,5 @@
 pluginInDir("${pluginType}" "TcpData" "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (NOT BUILDING_WITH_CONAN)
-	target_link_libraries("hobbits-plugin-importerexporters-TcpData" PRIVATE Qt5::Network)
+	target_link_libraries("hobbits-plugin-importerexporters-TcpData" PRIVATE Qt::Network)
 endif()

--- a/src/hobbits-plugins/importerexporters/UdpData/CMakeLists.txt
+++ b/src/hobbits-plugins/importerexporters/UdpData/CMakeLists.txt
@@ -1,5 +1,5 @@
 pluginInDir("${pluginType}" "UdpData" "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (NOT BUILDING_WITH_CONAN)
-	target_link_libraries("hobbits-plugin-importerexporters-UdpData" PRIVATE Qt5::Network)
+	target_link_libraries("hobbits-plugin-importerexporters-UdpData" PRIVATE Qt::Network)
 endif()

--- a/src/hobbits-runner/CMakeLists.txt
+++ b/src/hobbits-runner/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable("hobbits-runner" "${SRCFILES}"  "${HDRFILES}" "${RCFILES}")
 if (BUILDING_WITH_CONAN)
 	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core CONAN_PKG::qt)
 else()
-	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core Qt5::Widgets)
+	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core Qt::Widgets)
 endif()
 
 target_link_libraries("hobbits-runner" ${ALL_LINK_LIBS})


### PR DESCRIPTION
Qt 5.15 introduced versionless package detection to allow for Qt 5 & Qt6 compatibility.

https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html