### PR TITLE
Use versionless Qt cmake targets

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
-            os: [ubuntu-20.04, ubuntu-22.04]
+            os: [ubuntu-22.04]
 
     steps:
       - uses: actions/setup-node@v3

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
-            os: [ubuntu-20.04, ubuntu-22.04]
+            os: [ubuntu-22.04]
 
     steps:
       - uses: actions/setup-node@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.53.2](https://github.com/Mahlet-Inc/hobbits/compare/v0.53.1...v0.53.2) (2022-06-08)
+
+
+### Bug Fixes
+
+* correctly display kaitai value instances for [#145](https://github.com/Mahlet-Inc/hobbits/issues/145) ([556514b](https://github.com/Mahlet-Inc/hobbits/commit/556514b8a9192feaa0d88a8ec65083b90ebbab65))
+* fix kaitai plugin byte and string array sizes ([fdc2b10](https://github.com/Mahlet-Inc/hobbits/commit/fdc2b10c373a66c110488026e3b130ee47e5d65e))
+
 ## [0.53.1](https://github.com/Mahlet-Inc/hobbits/compare/v0.53.0...v0.53.1) (2022-03-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.53.4](https://github.com/Mahlet-Inc/hobbits/compare/v0.53.3...v0.53.4) (2023-02-17)
+
+
+### Bug Fixes
+
+* update the semantic release config and force a release ([59f69f5](https://github.com/Mahlet-Inc/hobbits/commit/59f69f53e480892c1e725996f06f8e976dc6efc3))
+
 ## [0.53.3](https://github.com/Mahlet-Inc/hobbits/compare/v0.53.2...v0.53.3) (2023-02-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.54.0](https://github.com/Mahlet-Inc/hobbits/compare/v0.53.4...v0.54.0) (2023-02-17)
+
+
+### Features
+
+* add Edit plugin ([9c091e5](https://github.com/Mahlet-Inc/hobbits/commit/9c091e5db0d9f7052116065b8c5351fc56df0b47))
+
 ## [0.53.4](https://github.com/Mahlet-Inc/hobbits/compare/v0.53.3...v0.53.4) (2023-02-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.53.3](https://github.com/Mahlet-Inc/hobbits/compare/v0.53.2...v0.53.3) (2023-02-17)
+
+
+### Bug Fixes
+
+* add prod build action and force a minor version bump ([4be6f45](https://github.com/Mahlet-Inc/hobbits/commit/4be6f4522db12958caf48e7fc6d65692f5009355))
+
 ## [0.53.2](https://github.com/Mahlet-Inc/hobbits/compare/v0.53.1...v0.53.2) (2022-06-08)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,9 +127,7 @@ else()
 	find_package(PkgConfig)
 
 	# Qt
-	find_package(Qt5Core CONFIG REQUIRED)
-	find_package(Qt5Widgets CONFIG REQUIRED)
-	find_package(Qt5Network CONFIG REQUIRED)
+	find_package(Qt5 5.15 REQUIRED COMPONENTS Core Widgets Network)
 
 	# libpcap
 	if (NOT WIN32)

--- a/cmake/PackExternalDeps.cmake
+++ b/cmake/PackExternalDeps.cmake
@@ -1,7 +1,7 @@
 
 function(pack_qt_libs)
 
-    get_target_property(QT_CORE_LIB Qt5::Core LOCATION)
+    get_target_property(QT_CORE_LIB Qt::Core LOCATION)
     if (APPLE)
         get_filename_component(CORE_FRAMEWORK_DIR "${QT_CORE_LIB}" DIRECTORY)
         get_filename_component(QT_LIB_DIR "${CORE_FRAMEWORK_DIR}" DIRECTORY)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hobbits",
-  "version": "0.53.1",
+  "version": "0.53.2",
   "private": true,
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hobbits",
-  "version": "0.53.2",
+  "version": "0.53.3",
   "private": true,
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hobbits",
-  "version": "0.53.4",
+  "version": "0.54.0",
   "private": true,
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hobbits",
-  "version": "0.53.3",
+  "version": "0.53.4",
   "private": true,
   "config": {
     "commitizen": {

--- a/src/hobbits-core/CMakeLists.txt
+++ b/src/hobbits-core/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(hobbits-core INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 if (BUILDING_WITH_CONAN)
 	set(ALL_LINK_LIBS CONAN_PKG::qt)
 else()
-	set(ALL_LINK_LIBS Qt5::Core Qt5::Widgets)
+	set(ALL_LINK_LIBS Qt::Core Qt::Widgets)
 endif()
 
 target_link_libraries(hobbits-core ${ALL_LINK_LIBS})

--- a/src/hobbits-gui/CMakeLists.txt
+++ b/src/hobbits-gui/CMakeLists.txt
@@ -19,7 +19,7 @@ file(GLOB RCFILES "${CMAKE_CURRENT_SOURCE_DIR}/*.qrc" "${CMAKE_CURRENT_SOURCE_DI
 if (BUILDING_WITH_CONAN)
 	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core CONAN_PKG::qt)
 else()
-	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core Qt5::Widgets)
+	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core Qt::Widgets)
 endif()
 
 add_executable(hobbits MACOSX_BUNDLE "${SRCFILES}" "${HDRFILES}" "${RCFILES}")

--- a/src/hobbits-plugins/CMakeLists.txt
+++ b/src/hobbits-plugins/CMakeLists.txt
@@ -18,7 +18,7 @@ macro(pluginInDir pluginType modName modDir)
 		if (BUILDING_WITH_CONAN)
 			set(ALL_LINK_LIBS hobbits-core hobbits-widgets CONAN_PKG::qt)
 		else()
-			set(ALL_LINK_LIBS hobbits-core hobbits-widgets Qt5::Core Qt5::Widgets)
+			set(ALL_LINK_LIBS hobbits-core hobbits-widgets Qt::Core Qt::Widgets)
 		endif()
 
         target_link_libraries("${pluginName}" PRIVATE ${ALL_LINK_LIBS})

--- a/src/hobbits-plugins/importerexporters/HttpData/CMakeLists.txt
+++ b/src/hobbits-plugins/importerexporters/HttpData/CMakeLists.txt
@@ -1,6 +1,6 @@
 pluginInDir("${pluginType}" "HttpData" "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (NOT BUILDING_WITH_CONAN)
-	target_link_libraries("hobbits-plugin-importerexporters-HttpData" PRIVATE Qt5::Network)
+	target_link_libraries("hobbits-plugin-importerexporters-HttpData" PRIVATE Qt::Network)
 endif()
     

--- a/src/hobbits-plugins/importerexporters/PacketCapture/CMakeLists.txt
+++ b/src/hobbits-plugins/importerexporters/PacketCapture/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT WIN32)
 	if (BUILDING_WITH_CONAN)
 		target_link_libraries("hobbits-plugin-importerexporters-PacketCapture" PRIVATE CONAN_PKG::libpcap)
 	else()
-		target_link_libraries("hobbits-plugin-importerexporters-PacketCapture" PRIVATE ${PCAP_LIBRARY} Qt5::Network)
+		target_link_libraries("hobbits-plugin-importerexporters-PacketCapture" PRIVATE ${PCAP_LIBRARY} Qt::Network)
 	endif()
     
 endif()

--- a/src/hobbits-plugins/importerexporters/TcpData/CMakeLists.txt
+++ b/src/hobbits-plugins/importerexporters/TcpData/CMakeLists.txt
@@ -1,5 +1,5 @@
 pluginInDir("${pluginType}" "TcpData" "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (NOT BUILDING_WITH_CONAN)
-	target_link_libraries("hobbits-plugin-importerexporters-TcpData" PRIVATE Qt5::Network)
+	target_link_libraries("hobbits-plugin-importerexporters-TcpData" PRIVATE Qt::Network)
 endif()

--- a/src/hobbits-plugins/importerexporters/UdpData/CMakeLists.txt
+++ b/src/hobbits-plugins/importerexporters/UdpData/CMakeLists.txt
@@ -1,5 +1,5 @@
 pluginInDir("${pluginType}" "UdpData" "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (NOT BUILDING_WITH_CONAN)
-	target_link_libraries("hobbits-plugin-importerexporters-UdpData" PRIVATE Qt5::Network)
+	target_link_libraries("hobbits-plugin-importerexporters-UdpData" PRIVATE Qt::Network)
 endif()

--- a/src/hobbits-runner/CMakeLists.txt
+++ b/src/hobbits-runner/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable("hobbits-runner" "${SRCFILES}"  "${HDRFILES}" "${RCFILES}")
 if (BUILDING_WITH_CONAN)
 	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core CONAN_PKG::qt)
 else()
-	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core Qt5::Widgets)
+	set(ALL_LINK_LIBS hobbits-python hobbits-widgets hobbits-core Qt::Widgets)
 endif()
 
 target_link_libraries("hobbits-runner" ${ALL_LINK_LIBS})


### PR DESCRIPTION
Qt 5.15 introduced versionless package detection. In the future this may allow for Qt 5 & Qt6 compatibility.

https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html
